### PR TITLE
ci: publish the NuGet packages conditionally

### DIFF
--- a/.ci/main.yml
+++ b/.ci/main.yml
@@ -3,6 +3,12 @@ name: $(Date:yyyyMMdd)$(Rev:-rr)
 trigger: 
   - uipath
 
+parameters:
+  - name: PublishNuGets
+    displayName: 'Publish the NuGet Packages'
+    type: boolean
+    default: false
+
 pool:
   vmImage: 'windows-2022'
   demands:
@@ -82,7 +88,12 @@ steps:
     projects: 'UiPath.FreeRdpClient\**\*.Tests.csproj'
 
 - task: NuGetCommand@2
-  displayName: 'NuGet Push to UiPath-Internal'
+  ${{ if eq(parameters.PublishNuGets, true) }}:
+    displayName: '(Enabled) NuGet Push to UiPath-Internal'
+    condition: succeeded()
+  ${{ if eq(parameters.PublishNuGets, false) }}:
+    displayName: '(Disabled) NuGet Push to UiPath-Internal'
+    condition: false
   inputs:
     command: push
     packagesToPush: 'Output\nugets\UiPath.FreeRdpClient.*.nupkg;Output\nugets\UiPath.SessionTools.*.nupkg'


### PR DESCRIPTION
## Make NuGet Package publishing conditional

- only **manual** runs that specify PublishNuGets=true will publish the NuGet package.
<img width="368" alt="image" src="https://github.com/UiPath/FreeRDP/assets/3280103/87433485-e814-4527-8ef7-91cc1b278fd1">

- commission the `PublishNuGets` parameter with default=false
- condition the step that published based on this parameter
- predict what'll happen by prefixing the NuGet Push step with either [Disabled] or [Enabled]

![image](https://github.com/UiPath/FreeRDP/assets/3280103/dd22cc92-4e53-4136-acdc-cc56a99d3ba3)



