### PR TITLE
NuGet: bump the minor to make room for patch bumps

### DIFF
--- a/UiPath.FreeRdpClient/Directory.Build.props
+++ b/UiPath.FreeRdpClient/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<AppVersion>2.5.0</AppVersion>
+		<AppVersion>2.6.0</AppVersion>
 		<Product>UiPath</Product>
 		<Company>UiPath</Company>
 		<Authors>UiPath</Authors>


### PR DESCRIPTION
Bumping the Minor (from 2.5.0 to 2.6.0) so that in a support/release branch, we have room to bump the Patch (from 2.5.0 to 2.5.1)