### PR TITLE
patch native logging logging filtering

### DIFF
--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/Logging.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/Logging.cs
@@ -29,12 +29,10 @@ internal class Logging : IHostedService
         "Decompression failure!",
         "Unknown bulk compression type 00000003",
         "Unsupported bulk compression type 00000003",
+        "order flags ",
         "history buffer index out of range",//10+
         "history buffer overflow",
         "fastpath_recv_update() - -1",
-        "order flags 03 failed",
-
-        "order flags 01 failed", //3+
     };
 
     public Logging(ILoggerFactory loggerFactory)


### PR DESCRIPTION
patch the native logging filtering
by generalizing the "order flags " rules into one and raising its priority