### PR TITLE
SessionTools: EnsureUserIsSetUp enhancements & target `net6.0` (no `-windows`)

### DIFF
--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/Faking/IUserContext.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/Faking/IUserContext.cs
@@ -41,6 +41,7 @@ public class UserContextReal : UserContextBase
         await new ProcessRunner(_log).EnsureUserIsSetUp(
             userDetail.GetLocalUserName(),
             userDetail.Password,
+            admin: true,
             ct);
     }
 

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/EnsureUserIsSetupTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/EnsureUserIsSetupTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using System.Security.Cryptography;
 using Xunit.Abstractions;
 
 namespace UiPath.SessionTools.Tests;
@@ -31,7 +30,7 @@ public class EnsureUserIsSetupTests : IAsyncLifetime
 
         using (ProcessRunner.TimeoutToken(TimeSpan.FromSeconds(5), out var ct))
         {
-            await _processRunner.EnsureUserIsSetUp(Username, _password, ct);
+            await _processRunner.EnsureUserIsSetUp(Username, _password, admin: true, ct);
         }
 
         _userChecks.UserExistsAndHasPassword(Username, _password).ShouldBeTrue();
@@ -43,8 +42,7 @@ public class EnsureUserIsSetupTests : IAsyncLifetime
                 info => info.AccountExpirationDate.ShouldBeNull(),
                 info => info.PasswordNeverExpires.ShouldBeTrue(),
                 info => info.UserCannotChangePassword.ShouldBeTrue(),
-                info => info.GroupNames.ShouldContain("Administrators"),
-                info => info.GroupNames.ShouldContain("Remote Desktop Users"));
+                info => info.GroupNames.ShouldContain("Administrators"));
     }
 
     private async Task EnsureUserIsDeleted()

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/UiPath.SessionTools.Tests.csproj
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/UiPath.SessionTools.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsUiPathTestProject>true</IsUiPathTestProject>

--- a/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/Commands.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/Commands.cs
@@ -15,18 +15,17 @@ public static class Commands
     /// <param name="password">The account's password.</param>
     /// <param name="ct">The operation's <see cref="CancellationToken"/>.</param>
     /// <returns></returns>
-    public static async Task EnsureUserIsSetUp(this ProcessRunner processRunner, string userName, string password, CancellationToken ct = default)
+    public static async Task EnsureUserIsSetUp(this ProcessRunner processRunner, string userName, string password, bool admin = false, CancellationToken ct = default)
     {
-        const string RemoteDesktopUsers = "Remote Desktop Users";
-        const string Administrators = "Administrators";
-
         await processRunner.EnsureUserHasPassword(userName, password, ct);
         await processRunner.ActivateUserAndDisableExpiration(userName, ct);
         await processRunner.ProhibitPasswordChange(userName, ct);
         await processRunner.DisablePasswordExpiration(userName, ct);
 
-        await processRunner.EnsureUserIsInGroup(userName, RemoteDesktopUsers, ct);
-        await processRunner.EnsureUserIsInGroup(userName, Administrators, ct);
+        if (admin)
+        {
+            await processRunner.EnsureUserIsInGroup(userName, "Administrators", ct);
+        }
     }
 
     internal static async Task<bool> UserExists(this ProcessRunner processRunner, string userName, CancellationToken ct = default)

--- a/UiPath.FreeRdpClient/UiPath.SessionTools/UiPath.SessionTools.csproj
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools/UiPath.SessionTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 


### PR DESCRIPTION
- Add a `bool admin = false` parameter to the `EnsureUserIsSetUp` extension method.
- Stop adding the user account to "Remote Desktop Users" as "Administrators" includes the same privileges.
- Drop the `-windows` constraint from UiPath.SessionTool's TFM
