### PR TITLE
SessionTools: Fix flaky tests [ROBO-3137]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,3 @@ cd .ci/Scripts
 * Open [UiPath.FreeRdpClient/UiPath.FreeRdpClient.sln](file://UiPath.FreeRdpClient/UiPath.FreeRdpClient.sln)
 * To test with a nugetRef instead of projectRef edit the [UiPath.FreeRdp.Tests.csproj](file://UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/UiPath.FreeRdp.Tests.csproj)
 search for: `<When Condition="'$(UseNugetRef)'!=''">`
-
-### Our current baseline from the original FreeRDP repo
-
-Check this [wiki page](./UiPath.FreeRdpClient/README.md)

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProcessRunnerTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProcessRunnerTests.cs
@@ -17,18 +17,18 @@ public class ProcessRunnerTests
 
         using var _ = ProcessRunner.TimeoutToken(deadline, out var ct);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var monitor = new ProgressMonitor();
+        var monitor = new StdMonitor();
 
         var task = runner.RunCore(
             fileName: "cmd.exe",
             arguments: $"/c echo {reachable1} & echo {reachable2} & ping -n {runTime.TotalSeconds} 127.0.0.1 & echo {unreachable}",
             workingDirectory: "",
-            stdoutProgress: monitor,
-            stderrProgress: null,
+            stdoutLines: monitor,
+            stderrLines: null,
             ct: linkedCts.Token);
 
-        await monitor.WaitForValue(reachable1, ct);
-        await monitor.WaitForValue(reachable2, ct);
+        await monitor.WaitForLine(reachable1, ct);
+        await monitor.WaitForLine(reachable2, ct);
 
         linkedCts.Cancel();
 

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProcessRunnerTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProcessRunnerTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-namespace UiPath.SessionTools.Tests;
+﻿namespace UiPath.SessionTools.Tests;
 
 [Trait("Subject", nameof(ProcessRunner))]
 public class ProcessRunnerTests
@@ -12,26 +10,33 @@ public class ProcessRunnerTests
         const string reachable2 = "4da0af0dae7246e998a5c579e922041f";
         const string unreachable = "44c681c32fd14b8fb3fda81371970f52";
 
-        var runTime = TimeSpan.FromSeconds(20);
-        var waitTime = TimeSpan.FromMilliseconds(300);
-        var waitLease = TimeSpan.FromSeconds(3);
+        var runTime = TimeSpan.FromDays(1);
+        var deadline = TimeSpan.FromMinutes(1);
 
         ProcessRunner runner = new();
 
-        using var _ = ProcessRunner.TimeoutToken(waitTime, out var ct);
+        using var _ = ProcessRunner.TimeoutToken(deadline, out var ct);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var monitor = new ProgressMonitor<string>();
 
-        var stopwatch = Stopwatch.StartNew();
-
-        var task = runner.Run(
+        var task = runner.RunCore(
             fileName: "cmd.exe",
             arguments: $"/c echo {reachable1} & echo {reachable2} & ping -n {runTime.TotalSeconds} 127.0.0.1 & echo {unreachable}",
-            ct);
+            workingDirectory: "",
+            stdoutProgress: monitor,
+            stderrProgress: null,
+            ct: linkedCts.Token);
+
+        await monitor.WaitForValue(candidate => candidate.TrimEnd() == reachable1, ct);
+        await monitor.WaitForValue(candidate => candidate.TrimEnd() == reachable2, ct);
+
+        linkedCts.Cancel();
 
         ProcessRunner.WaitCanceledException caught;
         try
         {
             var report = await task;
-            task.IsCanceled.ShouldBeTrue($"{report}");
+            task.IsCanceled.ShouldBeTrue($"{report}"); // fail with shouldly message
             throw null!;
         }
         catch (ProcessRunner.WaitCanceledException ex)
@@ -39,12 +44,10 @@ public class ProcessRunnerTests
             caught = ex;
         }
 
-        stopwatch.Stop();
-        stopwatch.Elapsed.ShouldBeLessThan(waitLease);
-
         caught.Report.ExitCode.ShouldBeNull();
         caught.Report.Stdout.ShouldContain(reachable1);
         caught.Report.Stdout.ShouldContain(reachable2);
         caught.Report.Stdout.ShouldNotContain(unreachable);
+        caught.Report.TryKill(entireProcessTree: true);
     }
 }

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProcessRunnerTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProcessRunnerTests.cs
@@ -17,7 +17,7 @@ public class ProcessRunnerTests
 
         using var _ = ProcessRunner.TimeoutToken(deadline, out var ct);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var monitor = new ProgressMonitor<string>();
+        var monitor = new ProgressMonitor();
 
         var task = runner.RunCore(
             fileName: "cmd.exe",
@@ -27,8 +27,8 @@ public class ProcessRunnerTests
             stderrProgress: null,
             ct: linkedCts.Token);
 
-        await monitor.WaitForValue(candidate => candidate.TrimEnd() == reachable1, ct);
-        await monitor.WaitForValue(candidate => candidate.TrimEnd() == reachable2, ct);
+        await monitor.WaitForValue(reachable1, ct);
+        await monitor.WaitForValue(reachable2, ct);
 
         linkedCts.Cancel();
 

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProgressMonitor.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProgressMonitor.cs
@@ -2,42 +2,27 @@
 
 namespace UiPath.SessionTools.Tests;
 
-internal sealed class ProgressMonitor<T> : IProgress<T>
-    where T : IEquatable<T>
+internal sealed class ProgressMonitor : IProgress<string>
 {
     private readonly AsyncMonitor _asyncMonitor = new();
-    private readonly List<T> _lines = new();
+    private readonly List<string> _values = new();
 
-    public async Task WaitForCount(int count, CancellationToken ct)
+    public async Task WaitForValue(string value, CancellationToken ct)
     {
         using (await _asyncMonitor.EnterAsync(ct))
         {
-            while (_lines.Count < count)
+            while (!_values.Any(c => c.TrimEnd() == value))
             {
                 await _asyncMonitor.WaitAsync(ct);
             }
         }
     }
 
-    public async Task WaitForValue(Func<T, bool> predicate, CancellationToken ct)
-    {
-        int cChecked = 0;
-
-        using (await _asyncMonitor.EnterAsync(ct))
-        {
-            while (!_lines.Skip(cChecked).Any(predicate))
-            {
-                cChecked = _lines.Count;
-                await _asyncMonitor.WaitAsync(ct);
-            }
-        }
-    }
-
-    async void IProgress<T>.Report(T value)
+    async void IProgress<string>.Report(string value)
     {
         using (await _asyncMonitor.EnterAsync())
         {
-            _lines.Add(value);
+            _values.Add(value);
             _asyncMonitor.PulseAll();
         }
     }

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProgressMonitor.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/ProgressMonitor.cs
@@ -1,0 +1,44 @@
+﻿using Nito.AsyncEx;
+
+namespace UiPath.SessionTools.Tests;
+
+internal sealed class ProgressMonitor<T> : IProgress<T>
+    where T : IEquatable<T>
+{
+    private readonly AsyncMonitor _asyncMonitor = new();
+    private readonly List<T> _lines = new();
+
+    public async Task WaitForCount(int count, CancellationToken ct)
+    {
+        using (await _asyncMonitor.EnterAsync(ct))
+        {
+            while (_lines.Count < count)
+            {
+                await _asyncMonitor.WaitAsync(ct);
+            }
+        }
+    }
+
+    public async Task WaitForValue(Func<T, bool> predicate, CancellationToken ct)
+    {
+        int cChecked = 0;
+
+        using (await _asyncMonitor.EnterAsync(ct))
+        {
+            while (!_lines.Skip(cChecked).Any(predicate))
+            {
+                cChecked = _lines.Count;
+                await _asyncMonitor.WaitAsync(ct);
+            }
+        }
+    }
+
+    async void IProgress<T>.Report(T value)
+    {
+        using (await _asyncMonitor.EnterAsync())
+        {
+            _lines.Add(value);
+            _asyncMonitor.PulseAll();
+        }
+    }
+}

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/PumpTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/PumpTests.cs
@@ -15,11 +15,11 @@ public class PumpTests
         using var _ = TimeoutToken(TimeSpan.FromMinutes(1), out var ct);
 
         MockReader reader = new(First);
-        var monitor = new ProgressMonitor();
+        var monitor = new StdMonitor();
         var pump = new Pump(reader, monitor);
         await using (pump)
         {
-            await monitor.WaitForValue($"{First + Count - 1}", ct);
+            await monitor.WaitForLine($"{First + Count - 1}", ct);
         }
 
         ValidateAccumulatedConsecutiveNumbers(pump, First);
@@ -36,10 +36,10 @@ public class PumpTests
 
         MockReader reader = new(skip: First, take: Take);
 
-        var monitor = new ProgressMonitor();
+        var monitor = new StdMonitor();
         await using var pump = new Pump(reader, monitor);
 
-        await monitor.WaitForValue($"{First + Take - 1}", ct);
+        await monitor.WaitForLine($"{First + Take - 1}", ct);
 
         ValidateAccumulatedConsecutiveNumbers(pump, First, ExclusiveLast);
     }

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/PumpTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/PumpTests.cs
@@ -6,6 +6,44 @@ namespace UiPath.SessionTools.Tests;
 [Trait("Subject", nameof(Pump))]
 public class PumpTests
 {
+    [Fact(DisplayName = $"{nameof(Pump.ToString)} should return consistent lines after pump disposal.")]
+    public async Task ToString_ShouldReturnConsistentLines_AfterPumpDisposal()
+    {
+        const ulong First = 12345;
+        const int Count = 20;
+
+        using var _ = TimeoutToken(TimeSpan.FromMinutes(1), out var ct);
+
+        MockReader reader = new(First);
+        var monitor = new ProgressMonitor<string>();
+        var pump = new Pump(reader, monitor);
+        await using (pump)
+        {
+            await monitor.WaitForCount(Count, ct);
+        }
+
+        ValidateAccumulatedConsecutiveNumbers(pump, First);
+    }
+
+    [Fact(DisplayName = $"{nameof(Pump.ToString)} should return consistent lines after the reader reaches the end-of-stream.")]
+    public async Task ToString_ShouldReturnConsistentLines_AfterReaderReachesEos()
+    {
+        const ulong First = 12345;
+        const int Take = 100;
+        const ulong ExclusiveLast = First + Take;
+
+        using var _ = TimeoutToken(TimeSpan.FromMinutes(1), out var ct);
+
+        MockReader reader = new(skip: First, take: Take);
+
+        var monitor = new ProgressMonitor<string>();
+        await using var pump = new Pump(reader, monitor);
+
+        await monitor.WaitForCount(Take, ct);
+
+        ValidateAccumulatedConsecutiveNumbers(pump, First, ExclusiveLast);
+    }
+
     private void ValidateAccumulatedConsecutiveNumbers(Pump pump, ulong expectedFirst, ulong? expectedExclusiveLast = null)
     {
         var lines = pump.ToString().Split("\r\n");
@@ -21,49 +59,6 @@ public class PumpTests
         }
 
         ulong.Parse(lines[lines.Length - 2]).ShouldBe(expectedExclusiveLast.Value - 1);
-    }
-
-    [Fact(DisplayName = $"{nameof(Pump.DisposeAsync)} should not throw.")]
-    public async Task DisposeAsync_ShouldNotThrow()
-    {
-        MockReader reader = new();
-        Pump pump = new(reader);
-
-        await Task.Delay(200);
-
-        var act = () => pump.DisposeAsync().AsTask();
-        await act.ShouldNotThrowAsync();
-    }
-
-    [Fact(DisplayName = $"{nameof(Pump.ToString)} should return consistent lines after pump disposal.")]
-    public async Task ToString_ShouldReturnConsistentLines_AfterPumpDisposal()
-    {
-        const ulong First = 12345;
-
-        MockReader reader = new(First);
-        Pump pump = new(reader);
-        await using (pump)
-        {
-            await Task.Delay(200);
-        }
-
-        ValidateAccumulatedConsecutiveNumbers(pump, First);
-    }
-
-    [Fact(DisplayName = $"{nameof(Pump.ToString)} should return consistent lines after the reader reaches the end-of-stream.")]
-    public async Task ToString_ShouldReturnConsistentLines_AfterReaderReachesEos()
-    {
-        const ulong First = 12345;
-        const int Take = 100;
-        const ulong ExclusiveLast = First + Take;
-
-        MockReader reader = new(First, take: 100);
-
-        await using Pump pump = new(reader);
-
-        await Task.Delay(200);
-
-        ValidateAccumulatedConsecutiveNumbers(pump, First, ExclusiveLast);
     }
 
     private sealed class MockReader : StreamReader

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/PumpTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/PumpTests.cs
@@ -15,11 +15,11 @@ public class PumpTests
         using var _ = TimeoutToken(TimeSpan.FromMinutes(1), out var ct);
 
         MockReader reader = new(First);
-        var monitor = new ProgressMonitor<string>();
+        var monitor = new ProgressMonitor();
         var pump = new Pump(reader, monitor);
         await using (pump)
         {
-            await monitor.WaitForCount(Count, ct);
+            await monitor.WaitForValue($"{First + Count - 1}", ct);
         }
 
         ValidateAccumulatedConsecutiveNumbers(pump, First);
@@ -36,10 +36,10 @@ public class PumpTests
 
         MockReader reader = new(skip: First, take: Take);
 
-        var monitor = new ProgressMonitor<string>();
+        var monitor = new ProgressMonitor();
         await using var pump = new Pump(reader, monitor);
 
-        await monitor.WaitForCount(Take, ct);
+        await monitor.WaitForValue($"{First + Take - 1}", ct);
 
         ValidateAccumulatedConsecutiveNumbers(pump, First, ExclusiveLast);
     }

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/StdMonitor.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/StdMonitor.cs
@@ -2,16 +2,16 @@
 
 namespace UiPath.SessionTools.Tests;
 
-internal sealed class ProgressMonitor : IProgress<string>
+internal sealed class StdMonitor : IProgress<string>
 {
     private readonly AsyncMonitor _asyncMonitor = new();
-    private readonly List<string> _values = new();
+    private readonly List<string> _lines = new();
 
-    public async Task WaitForValue(string value, CancellationToken ct)
+    public async Task WaitForLine(string line, CancellationToken ct)
     {
         using (await _asyncMonitor.EnterAsync(ct))
         {
-            while (!_values.Any(c => c.TrimEnd() == value))
+            while (!_lines.Any(c => c.TrimEnd() == line))
             {
                 await _asyncMonitor.WaitAsync(ct);
             }
@@ -22,7 +22,7 @@ internal sealed class ProgressMonitor : IProgress<string>
     {
         using (await _asyncMonitor.EnterAsync())
         {
-            _values.Add(value);
+            _lines.Add(value);
             _asyncMonitor.PulseAll();
         }
     }

--- a/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/UiPath.SessionTools.Tests.csproj
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools.Tests/UiPath.SessionTools.Tests.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="Microsoft.SourceLink.GitHub" />
       <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+	  <PackageReference Include="Nito.AsyncEx" />
 	  <PackageReference Include="System.DirectoryServices.AccountManagement" Version="7.0.0" />
 	</ItemGroup>
 

--- a/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.Pump.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.Pump.cs
@@ -9,18 +9,19 @@ partial class ProcessRunner
         private readonly StreamReader _stream;
         private readonly Task _task;
 
-        public Pump(StreamReader stream)
+        public Pump(StreamReader stream, IProgress<string>? progress = null)
         {
             _stream = stream;
             _task = Task.Run(async () =>
                 {
                     try
                     {
-                        while (await stream.ReadLineAsync() is { } notNull)
+                        while (await stream.ReadLineAsync() is { } line)
                         {
                             lock (_lock)
                             {
-                                _inner.AppendLine(notNull);
+                                _inner.AppendLine(line);
+                                progress?.Report(line);
                             }
                         }
                     }

--- a/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.Report.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.Report.cs
@@ -19,5 +19,16 @@ partial class ProcessRunner
             0 => Logging.Formatting.FormatRunSucceeded(StartInfo.FileName, StartInfo.Arguments, Stdout, Stderr),
             _ => Logging.Formatting.FormatRunFailed(StartInfo.FileName, StartInfo.Arguments, $"{ExitCode}", Stdout, Stderr)
         };
+
+        public void TryKill(bool entireProcessTree = false)
+        {
+            using var process = Process.GetProcessById(ProcessId);
+            if (process is null || process.StartTime != ProcessStartTime)
+            {
+                return;
+            }
+
+            process.Kill(entireProcessTree);
+        }
     }
 }

--- a/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.cs
@@ -26,9 +26,9 @@ public partial class ProcessRunner
     }
 
     public virtual Task<Report> Run(string fileName, string arguments, string workingDirectory, CancellationToken ct = default)
-    => RunCore(fileName, arguments, workingDirectory, stdoutProgress: null, stderrProgress: null, ct: ct);
+    => RunCore(fileName, arguments, workingDirectory, stdoutLines: null, stderrLines: null, ct: ct);
 
-    internal async Task<Report> RunCore(string fileName, string arguments, string workingDirectory, IProgress<string>? stdoutProgress = null, IProgress<string>? stderrProgress = null, CancellationToken ct = default)
+    internal async Task<Report> RunCore(string fileName, string arguments, string workingDirectory, IProgress<string>? stdoutLines = null, IProgress<string>? stderrLines = null, CancellationToken ct = default)
     {
         var startInfo = StartInfo();
         _logger?.LogRunStarted(startInfo);
@@ -39,8 +39,8 @@ public partial class ProcessRunner
         int processId = process.Id;
         DateTime processStartTime = process.StartTime;
 
-        Pump stdout = new(process.StandardOutput, stdoutProgress);
-        Pump stderr = new(process.StandardError, stderrProgress);
+        Pump stdout = new(process.StandardOutput, stdoutLines);
+        Pump stderr = new(process.StandardError, stderrLines);
 
         try
         {

--- a/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/ProcessRunner.cs
@@ -25,7 +25,10 @@ public partial class ProcessRunner
         _logger = logger;
     }
 
-    public virtual async Task<Report> Run(string fileName, string arguments, string workingDirectory, CancellationToken ct = default)
+    public virtual Task<Report> Run(string fileName, string arguments, string workingDirectory, CancellationToken ct = default)
+    => RunCore(fileName, arguments, workingDirectory, stdoutProgress: null, stderrProgress: null, ct: ct);
+
+    internal async Task<Report> RunCore(string fileName, string arguments, string workingDirectory, IProgress<string>? stdoutProgress = null, IProgress<string>? stderrProgress = null, CancellationToken ct = default)
     {
         var startInfo = StartInfo();
         _logger?.LogRunStarted(startInfo);
@@ -36,8 +39,8 @@ public partial class ProcessRunner
         int processId = process.Id;
         DateTime processStartTime = process.StartTime;
 
-        Pump stdout = new(process.StandardOutput);
-        Pump stderr = new(process.StandardError);
+        Pump stdout = new(process.StandardOutput, stdoutProgress);
+        Pump stderr = new(process.StandardError, stderrProgress);
 
         try
         {


### PR DESCRIPTION
Some SessionTools time-based unit tests were failing due to slow build agents.
Now the tests have a much broader time lease but succeed asap because they monitor the outcome continuously.

### Supplemental:

Remove the broken hyperlink in the root README.md
