### PR TITLE
Guard against a nullptr callback

### DIFF
--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/Faking/IUserContext.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/Faking/IUserContext.cs
@@ -3,13 +3,15 @@ using Newtonsoft.Json;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
+using UiPath.Rdp;
 using UiPath.SessionTools;
 
 namespace UiPath.FreeRdp.Tests.Faking;
 
 public class UserExistsDetail
 {
-    private NetworkCredential _credentials = new NetworkCredential();
+    private readonly NetworkCredential _credentials = new();
+
     public string UserName { get => _credentials.GetFullUserName(); set => _credentials.SetFullUserName(value); }
     public string Password { get => _credentials.Password; set => _credentials.Password = value; }
 
@@ -18,6 +20,12 @@ public class UserExistsDetail
         .Replace(UserNames.DefaultDomainName.ToLowerInvariant() + "\\", "");
 
     public List<string> Groups { get; } = new() { "Remote Desktop Users", "Administrators" };
+
+    public RdpConnectionSettings ToRdpConnectionSettings()
+    => new(
+        username: UserName.Split("\\")[1],
+        password: Password,
+        domain: UserName.Split("\\")[0]);
 }
 
 public interface IUserContext

--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/LoggingTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/LoggingTests.cs
@@ -60,13 +60,7 @@ public class LoggingTests : TestsBase
     public async Task ShouldProduceLogsFromFreerdp()
     {
         var user = await Host.GivenUser();
-        var connectionSettings = new RdpConnectionSettings(
-            username: user.UserName.Split("\\")[1],
-            password: user.Password,
-            domain: user.UserName.Split("\\")[0]
-        )
-        {
-        };
+        var connectionSettings = user.ToRdpConnectionSettings();
 
         await using var sut = await Connect(connectionSettings);
         var sessionId = WtsApi.FindFirstSessionByClientName(connectionSettings.ClientName)

--- a/UiPath.FreeRdpClient/UiPath.FreeRdpWrapper/Logging.cpp
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpWrapper/Logging.cpp
@@ -11,6 +11,9 @@ namespace Logging
 
 	BOOL wLog_Message(const wLogMessage* msg)
 	{
+		if (!_clientLogCallback)
+			return FALSE;
+
 		wchar_t wbuffer[MAX_TRACE_MSG];
 		mbstowcs_s(nullptr, wbuffer, msg->TextString, MAX_TRACE_MSG);
 


### PR DESCRIPTION
## Main purpose (the fix)

This PR addresses an access violation exception (NullReferenceException) that occurred when we assigned `nullptr` to FreeRdpWrapper's `Logging._clientLogCallback` pointer. This assignment is (still) performed as part of the disposal of FreeRdpClient's `NativeLoggingForwarder`, which in turn happens as part of the disposal of the `Microsoft.Extensions.Hosting` host.

## Additional changes

- The PR ✨**tentatively** introduces a test that was manually proven to crash the test runner in the absence of the fix.
  If a degrade occurs, the CI will not report the error comprehensively but will crash.
  
![image](https://github.com/UiPath/FreeRDP/assets/3280103/af519531-dc97-47c1-912a-8b33b17d88e5)


- It also commissions the `UserExistsDetail.ToRdpConnectionSettings` method, which is used in 8 places. This method looks like an extension method but isn't.
![image](https://github.com/UiPath/FreeRDP/assets/3280103/7382f349-0e4f-4622-b0c1-f78b2c73d696)
