### PR TITLE
Filter out "Primary Drawing Order..." warnings in the logs

### DIFF
--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/LoggingTests.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient.Tests/LoggingTests.cs
@@ -104,6 +104,7 @@ public class LoggingTests : TestsBase
     {
         var forwarder = Host.GetRequiredService<NativeLoggingForwarder>();
         forwarder.FilterRemoveStartsWith = new[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString() };
+        forwarder.FilterRemoveStartsWithWarnings = new[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString() };
 
         var someTestCategory = Guid.NewGuid().ToString();
         var testLogs = _logsByCategory.Where(kv => kv.Key == someTestCategory)
@@ -115,16 +116,26 @@ public class LoggingTests : TestsBase
             forwarder.LogCallbackDelegate(someTestCategory, LogLevel.Error, startWith + "_extra2");
             forwarder.LogCallbackDelegate(someTestCategory, LogLevel.Error, startWith);
         }
+        foreach (var startWith in forwarder.FilterRemoveStartsWithWarnings)
+        {
+            forwarder.LogCallbackDelegate(someTestCategory, LogLevel.Warning, startWith + "_extra1");
+            forwarder.LogCallbackDelegate(someTestCategory, LogLevel.Warning, startWith + "_extra2");
+            forwarder.LogCallbackDelegate(someTestCategory, LogLevel.Warning, startWith);
+        }
         testLogs.ShouldBeEmpty();
 
         foreach (var startWith in forwarder.FilterRemoveStartsWith)
         {
             forwarder.LogCallbackDelegate(someTestCategory, LogLevel.Error, "_" + startWith);
         }
+        foreach (var startWith in forwarder.FilterRemoveStartsWithWarnings)
+        {
+            forwarder.LogCallbackDelegate(someTestCategory, LogLevel.Warning, "_" + startWith);
+        }
         testLogs.Count()
-            .ShouldBe(forwarder.FilterRemoveStartsWith.Length);
+            .ShouldBe(forwarder.FilterRemoveStartsWith.Length + forwarder.FilterRemoveStartsWithWarnings.Length);
         testLogs.Count(l => l.logLevel is LogLevel.Warning)
-            .ShouldBe(forwarder.FilterRemoveStartsWith.Length);
+            .ShouldBe(forwarder.FilterRemoveStartsWith.Length + forwarder.FilterRemoveStartsWithWarnings.Length);
         testLogs.Where(l => l.logLevel is LogLevel.Error)
             .ShouldBeEmpty();
     }

--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/NativeLoggingForwarder.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/NativeLoggingForwarder.cs
@@ -32,6 +32,7 @@ internal sealed class NativeLoggingForwarder : IDisposable
         "history buffer index out of range",//10+
         "history buffer overflow",
         "fastpath_recv_update() - -1",
+        "Primary Drawing Order"
     };
 
     public NativeLoggingForwarder(ILoggerFactory loggerFactory)

--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/NativeLoggingForwarder.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/NativeLoggingForwarder.cs
@@ -32,7 +32,11 @@ internal sealed class NativeLoggingForwarder : IDisposable
         "history buffer index out of range",//10+
         "history buffer overflow",
         "fastpath_recv_update() - -1",
-        "Primary Drawing Order"
+    };
+
+    public string[] FilterRemoveStartsWithWarnings = new[]
+    {
+        "Primary Drawing Order",
     };
 
     public NativeLoggingForwarder(ILoggerFactory loggerFactory)
@@ -73,7 +77,11 @@ internal sealed class NativeLoggingForwarder : IDisposable
     private bool FilterLogs(LogLevel logLevel, string message)
     {
         if (logLevel is LogLevel.Error
-            && FilterRemoveStartsWith.Any(message.StartsWith))
+            && Array.Exists(FilterRemoveStartsWith, message.StartsWith))
+            return false;
+
+        if (logLevel is LogLevel.Warning
+            && Array.Exists(FilterRemoveStartsWithWarnings, message.StartsWith))
             return false;
 
         return true;


### PR DESCRIPTION
We don't want these repeated warnings in the Robot logs:

```python
2023-11-17T11:26:38.6516541+01:00 => [WARN] [UiPath.Service.Host] [com.freerdp.core.update] [23.12.0.0] [RDP_100_1]
Primary Drawing Order [0x01] PatBlt failed

2023-11-17T11:26:38.6516541+01:00 => [WARN] [UiPath.Service.Host] [com.freerdp.core.update] [23.12.0.0] [RDP_100_1]
Primary Drawing Order [0x01] PatBlt failed

2023-11-17T11:26:38.6516541+01:00 => [WARN] [UiPath.Service.Host] [com.freerdp.core.update] [23.12.0.0] [RDP_100_1]
Primary Drawing Order [0x01] PatBlt failed

```
