### PR TITLE
[ROBO-3631] Add support for usernames containing spaces or single quotes

### DIFF
--- a/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/Commands.cs
+++ b/UiPath.FreeRdpClient/UiPath.SessionTools/Processes/Commands.cs
@@ -30,14 +30,14 @@ public static class Commands
 
     internal static async Task<bool> UserExists(this ProcessRunner processRunner, string userName, CancellationToken ct = default)
     {
-        var report = await processRunner.Run("net", $"user {userName}", ct: ct);
+        var report = await processRunner.Run("net", $"user \"{userName}\"", ct: ct);
         return report.exitCode is 0;
     }
     internal static Task CreateUser(this ProcessRunner processRunner, string userName, string password, CancellationToken ct = default)
-    => processRunner.Run("net", $"user {userName} {password} /add", throwOnNonZero: true, ct: ct);
+    => processRunner.Run("net", $"user \"{userName}\" {password} /add", throwOnNonZero: true, ct: ct);
 
     internal static Task SetPassword(this ProcessRunner processRunner, string userName, string password, CancellationToken ct = default)
-    => processRunner.Run("net", $"user {userName} {password}", throwOnNonZero: true, ct: ct);
+    => processRunner.Run("net", $"user \"{userName}\" {password}", throwOnNonZero: true, ct: ct);
         
     internal static async Task EnsureUserHasPassword(this ProcessRunner processRunner, string userName, string password, CancellationToken ct = default)
     {
@@ -51,15 +51,15 @@ public static class Commands
     }
     internal static Task ActivateUserAndDisableExpiration(this ProcessRunner processRunner, string userName, CancellationToken ct = default)
     => processRunner
-        .Run("net", $"user {userName} /active /expires:never", throwOnNonZero: true, ct: ct);
+        .Run("net", $"user \"{userName}\" /active /expires:never", throwOnNonZero: true, ct: ct);
 
     internal static Task ProhibitPasswordChange(this ProcessRunner processRunner, string userName, CancellationToken ct = default)
     => processRunner
-        .Run("net", $"user {userName} /passwordchg:no", throwOnNonZero: true, ct: ct);
+        .Run("net", $"user \"{userName}\" /passwordchg:no", throwOnNonZero: true, ct: ct);
 
     internal static Task DisablePasswordExpiration(this ProcessRunner processRunner, string userName, CancellationToken ct = default)
-    => processRunner.Run("wmic", $"useraccount WHERE Name='{userName}' set PasswordExpires=false", throwOnNonZero: true, ct: ct);
+    => processRunner.Run("wmic", $"useraccount WHERE Name='{userName.Replace("'","\\'")}' set PasswordExpires=false", throwOnNonZero: true, ct: ct);
         
     internal static Task EnsureUserIsInGroup(this ProcessRunner processRunner, string userName, string groupName, CancellationToken ct = default)
-    => processRunner.Run("net", $"localgroup \"{groupName}\" {userName} /add", ct: ct);
+    => processRunner.Run("net", $"localgroup \"{groupName}\" \"{userName}\" /add", ct: ct);
 }


### PR DESCRIPTION
Usernames containing spaces or single quotes character would lead to command errors when being parsed, they have been surrounded by double quotes where possible or explicit handling has been added.

