### PR TITLE
Update FreeRDP log filters ROBO-5260

### DIFF
--- a/.ci/Scripts/buildFreeRdp.bat
+++ b/.ci/Scripts/buildFreeRdp.bat
@@ -21,6 +21,7 @@ cmd /c cmake . -B"./Build/x64" -G"Visual Studio 17 2022"^
     -DWITH_DSP_FFMPEG=OFF^
     -DWITH_SWSCALE=OFF^
     -DWITH_SHADOW=OFF^
+    -DWITH_VERBOSE_WINPR_ASSERT=OFF
 
 rem build freerdp libs
 set Configuration=%1

--- a/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/NativeLoggingForwarder.cs
+++ b/UiPath.FreeRdpClient/UiPath.FreeRdpClient/Internals/NativeLoggingForwarder.cs
@@ -16,7 +16,9 @@ internal sealed class NativeLoggingForwarder : IDisposable
         // ordered by frequency
         "freerdp_check_fds() failed - 0", //24000+ in 50 sec
         "WARNING: invalid packet signature",
-        "transport_check_fds: transport->ReceiveCallback() - -4",
+        "transport_check_fds: transport->ReceiveCallback() - -4", // logged by 2.5
+        "transport_check_fds: transport->ReceiveCallback() - STATE_RUN_FAILED", // logged by 3.16
+        "CONNECTION_STATE_ACTIVE status STATE_RUN_FAILED", // logged just before the one above on 3.16
         "fastpath_recv_update_data() fail",
         "Stream_GetRemainingLength() < size",//20000+ in 50 sec
         "fastpath_recv_update_data: fastpath_recv_update() -",
@@ -24,6 +26,7 @@ internal sealed class NativeLoggingForwarder : IDisposable
         "Total size (", // 21234214) exceeds MultifragMaxRequestSize (65535) // 2000+ in 50 secs
         "Unexpected FASTPATH_FRAGMENT_SINGLE",//800+ in 50 sec
         "SECONDARY ORDER [0x",//<04/05/...>] Cache Bitmap V2 (Compressed) failed",
+        "Secondary Drawing Order [0x", // same as above, logged by 3.16
         "bulk_decompress() failed",
         "Decompression failure!",
         "Unknown bulk compression type 00000003",
@@ -32,11 +35,15 @@ internal sealed class NativeLoggingForwarder : IDisposable
         "history buffer index out of range",//10+
         "history buffer overflow",
         "fastpath_recv_update() - -1",
+        "Primary Drawing Order",
     };
 
     public string[] FilterRemoveStartsWithWarnings = new[]
     {
         "Primary Drawing Order",
+        "expected messageChannelId=0",
+        "license binary blob::type BB_ERROR_BLOB",
+        "This build does not support AAD security"
     };
 
     public NativeLoggingForwarder(ILoggerFactory loggerFactory)


### PR DESCRIPTION
The upgrade from 2.5 to 3.16 included some log changes that we were
filtering. This caused Robot logs to be filled with spammy logs after
the upgrade.

The logs in question are:

"transport_check_fds: transport->ReceiveCallback() - STATE_RUN_FAILED"

This log would return an int on some fast path, it's now changed to a
string.

2.5 - https://github.com/UiPath/FreeRDP/blob/201e456468863dacf29e270f75d2f59325df667a/libfreerdp/core/fastpath.c#L669
3.16 - https://github.com/FreeRDP/FreeRDP/blob/969235f7cfb6778306f362be53507326ab0ef867/libfreerdp/core/fastpath.c#L657

"CONNECTION_STATE_ACTIVE status STATE_RUN_FAILED [-1]"

This log is missing from 2.5.

2.5 - https://github.com/UiPath/FreeRDP/blob/201e456468863dacf29e270f75d2f59325df667a/libfreerdp/core/rdp.c#L1679
3.16 - https://github.com/FreeRDP/FreeRDP/blob/fcdf4c6c7e7ffda9203889114a2ee7ba8d5d1976/libfreerdp/core/rdp.c#L2180

"Secondary Drawing Order [0x"

2.5 - https://github.com/UiPath/FreeRDP/blob/201e456468863dacf29e270f75d2f59325df667a/libfreerdp/core/orders.c#L3916
3.16 - https://github.com/FreeRDP/FreeRDP/blob/fcdf4c6c7e7ffda9203889114a2ee7ba8d5d1976/libfreerdp/core/orders.c#L4253

"Primary Drawing Order"

This one was changed from warning to error

2.5 - https://github.com/UiPath/FreeRDP/blob/201e456468863dacf29e270f75d2f59325df667a/libfreerdp/core/orders.c#L3746
3.16 - https://github.com/FreeRDP/FreeRDP/blob/fcdf4c6c7e7ffda9203889114a2ee7ba8d5d1976/libfreerdp/core/orders.c#L4072

Also ignored three more warning logs - two show up during connect and is
related to a compile flag that wasn't used.
