### PR TITLE
Disable USE_VERSION_FROM_GIT_TAG ROBO-5330

### DIFF
--- a/.ci/Scripts/buildFreeRdp.bat
+++ b/.ci/Scripts/buildFreeRdp.bat
@@ -21,7 +21,8 @@ cmd /c cmake . -B"./Build/x64" -G"Visual Studio 17 2022"^
     -DWITH_DSP_FFMPEG=OFF^
     -DWITH_SWSCALE=OFF^
     -DWITH_SHADOW=OFF^
-    -DWITH_VERBOSE_WINPR_ASSERT=OFF
+    -DWITH_VERBOSE_WINPR_ASSERT=OFF^
+    -DUSE_VERSION_FROM_GIT_TAG=OFF
 
 rem build freerdp libs
 set Configuration=%1

--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -153,7 +153,7 @@ if(WITH_VAAPI_H264_ENCODING)
   add_definitions("-DWITH_VAAPI_H264_ENCODING")
 endif()
 
-option(USE_VERSION_FROM_GIT_TAG "Extract FreeRDP version from git tag." ON)
+option(USE_VERSION_FROM_GIT_TAG "Extract FreeRDP version from git tag." OFF)
 
 option(WITH_CAIRO "Use CAIRO image library for screen resizing" OFF)
 option(WITH_SWSCALE "Use SWScale image library for screen resizing" ON)

--- a/cmake/ConfigOptions.cmake
+++ b/cmake/ConfigOptions.cmake
@@ -153,7 +153,7 @@ if(WITH_VAAPI_H264_ENCODING)
   add_definitions("-DWITH_VAAPI_H264_ENCODING")
 endif()
 
-option(USE_VERSION_FROM_GIT_TAG "Extract FreeRDP version from git tag." OFF)
+option(USE_VERSION_FROM_GIT_TAG "Extract FreeRDP version from git tag." ON)
 
 option(WITH_CAIRO "Use CAIRO image library for screen resizing" OFF)
 option(WITH_SWSCALE "Use SWScale image library for screen resizing" ON)


### PR DESCRIPTION
## Description

By default `USE_VERSION_FROM_GIT_TAG` is enabled which means thath CMake will use the tag that matches the head of the branch to determine the version. 

If we create a tag after publishing a new version and then run the build pipeline again from the same commit, the version will be extracted from our tag and will be something like `4.2.0`.

<img width="1941" height="368" alt="image" src="https://github.com/user-attachments/assets/253fcc45-d2cc-4b44-b8e2-0324f273a670" />

If we disable this option, it will use the version hardcoded in `RAW_VERSION_STRING` which is `3.16.0`.

https://github.com/UiPath/FreeRDP/blob/615e157440a023fae2db8b617e86800ecff6db21/CMakeLists.txt#L104

This problem occurred after a tag `UiPath.FreeRdpClient.24.2.0-20260202-02` was created by [this run](https://uipath.visualstudio.com/Studio/_build/results?buildId=11049509&view=results).

This caused the [next run](https://uipath.visualstudio.com/Studio/_build/results?buildId=11181450&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=93aa0150-41c9-5713-ecef-209bb4ac80da&s=96ac2280-8cb4-5df5-99de-dd2da759617d) from the same commit to fail because `freerdp3.lib` and `winpr3.lib` weren't found.

If you build FreeRDP locally from commit `615e157440a023fae2db8b617e86800ecff6db21` (HEAD of `uipath-3.16` at the moment) you'll notice that the output lib is named `freerdp4.lib`.

<img width="573" height="243" alt="image" src="https://github.com/user-attachments/assets/f2344735-e677-4cd1-8850-b0c04969cd54" />
